### PR TITLE
Added xchen and jarnstein to the list of authors

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -36,6 +36,7 @@ active-authors:
     - hbellamy
     - hgoode
     - hubinf
+    - jarnstein
     - jbeckles
     - jdunleavy
     - jgrant
@@ -96,6 +97,7 @@ active-authors:
     - wreilly
     - wsalt
     - wtrimble
+    - xchen
     - zrubin
     - zwali
 authors:
@@ -1173,3 +1175,11 @@ authors:
         author-summary: 'I am a Technical Architect at Scott Logic.'
         twitter-handle: null
         picture: null
+    xchen:
+        name: 'Xin Chen'
+        author-summary: 'I am a lead test engineer at Scott Logic. For the last 15 years, I had the pleasure to work with different people with different backgrounds and focus areas. I am passionate about the latest concept and technology used in Quality Assurance. In my spare time, I enjoy traveling and exploring the varied culture. I used to live in four different counties.'
+        picture: picture.jpeg
+    jarnstein:
+        name: 'Jack Arnstein'
+        author-summary: 'I am a senior tester at Scott Logic with a passion for all things security related. In my spare time I enjoy board games with my family and friends. I also enjoy Lego with my eldest, as well as assisting my junior twin testers in their explorative testing of all things in the known world.'
+        picture: picture.jpeg


### PR DESCRIPTION
Now shows xchen and jarnstein on the https://gsproston-scottlogic.github.io/scottlogic-blog/2022/06/15/beyond-the-hype-bdd.html post.