### PR TITLE
Add script and instructions for running blog locally via Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Gemfile.lock
 
 .bundle/
 .vscode/
+
+/container_gem_cache/
+/dist/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,29 @@ __NOTE__: Instructions are work in progress.
 
 The blog consists of static HTML pages with content generated using Jekyll markdown.
 
+### Docker:
+
+Use a bash-compatible shell.
+
+**Install gem dependencies**
+
+First, output gem dependencies to a directory `container_gem_cache` on our host machine:
+
+```bash
+./shell/docker-gem-install.sh
+```
+
+**Run dev watch**
+
+Now we can serve the blog:
+
+```bash
+BLOG_USERNAME=abirch ./shell/docker-dev-watch.sh
+```
+
+Visit the blog at:  
+http://localhost:4000
+
 ### Linux:
 
 1. sudo apt-get install ruby2.3 ruby2.3-dev build-essential dh-autoreconf
@@ -55,5 +78,3 @@ To minify SCSS, run:
 ```
 npm run style
 ```
-
-

--- a/shell/docker-dev-watch.sh
+++ b/shell/docker-dev-watch.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPTDIR="$(dirname "$0")"
+REPOROOT="$(realpath "$SCRIPTDIR/..")"
+
+CONTAINER_WORKDIR=/srv/jekyll
+
+Red='\033[0;31m'
+Purple='\033[0;35m'
+NC='\033[0m' # No Color
+
+if [[ -z "$BLOG_USERNAME" ]]; then
+  >&2 echo -e "${Red}BLOG_USERNAME env var not set.${NC}"
+  >&2 echo -e "Set it to the username derived from your Scott Logic email address.\nFor example, for ABirch@scottlogic.com:"
+  >&2 echo -e "${Purple}export BLOG_USERNAME=abirch${NC}"
+  exit 1
+fi
+
+SERVE_MOUNTS=(
+  _data
+  _includes
+  _layouts
+  _posts
+  _uploads
+  assets
+  category
+  scripts
+  scss
+  404.html
+  _config.yml
+  _prose.yml
+  atom.xml
+  CNAME
+  Enter
+  index.html
+  script.js
+  style.css
+  scott-logic-block.markdown
+  robots.txt
+)
+
+SERVE_MOUNT_ARGS=()
+for fname in "${SERVE_MOUNTS[@]}"; do
+  SERVE_MOUNT_ARGS+=(-v "$REPOROOT/$fname":"$CONTAINER_WORKDIR/$fname":ro)
+done
+
+# accept PORT env var, fallback to 4000 if unspecified
+: "${PORT:=4000}"
+
+set -x
+
+# run jekyll serve
+# https://jekyllrb.com/docs/configuration/options/
+# TODO: consider serving with --incremental if updates are slow
+exec docker run -it --rm --init \
+--name sl-jekyll-run \
+-v "$REPOROOT/$BLOG_USERNAME":"$CONTAINER_WORKDIR/"$BLOG_USERNAME":ro" \
+-v "$REPOROOT/container_gem_cache":"$CONTAINER_WORKDIR/.bundle:ro" \
+"${SERVE_MOUNT_ARGS[@]}" \
+-v "$REPOROOT/dist":/dist \
+-p "$PORT":"$PORT" \
+-p 35729:35729 \
+-p 3000:3000 \
+jekyll/jekyll:3.8.6 jekyll serve --livereload -d /dist --port "$PORT"

--- a/shell/docker-gem-install.sh
+++ b/shell/docker-gem-install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPTDIR="$(dirname "$0")"
+REPOROOT="$(realpath "$SCRIPTDIR/..")"
+
+CONTAINER_WORKDIR=/srv/jekyll
+
+touch "$REPOROOT/Gemfile.lock"
+
+set -x
+
+# runs `bundle install` to fetch the gem dependencies listed in our Gemfile + Gemfile.lock,
+# and installs them to container_gem_cache (which we output to the host OS).
+# if our Gemfile.lock is currently empty: the container will resolve deps and output one for us
+# https://bundler.io/v2.4/man/bundle-install.1.html
+exec docker run -it --rm --init \
+--name sl-blog-gem-install \
+-v "$REPOROOT/Gemfile":"$CONTAINER_WORKDIR/Gemfile":ro \
+-v "$REPOROOT/Gemfile.lock":"$CONTAINER_WORKDIR/Gemfile.lock" \
+-v "$REPOROOT/container_gem_cache":/usr/local/bundle \
+jekyll/jekyll:3.8.6 bundle


### PR DESCRIPTION
`docker-gem-install.sh` installs gem dependencies:  
<img width="1080" alt="image" src="https://github.com/ScottLogic/blog/assets/40387940/b834fb18-bcab-465a-8027-bb0b14bc77e8">

`docker-dev-watch.sh` runs the blog in dev watch mode:
<img width="1134" alt="image" src="https://github.com/ScottLogic/blog/assets/40387940/e7ab7aa9-7158-435c-8602-6fb8c89421ab">

Blog gets deployed to localhost:4000 with dev watch + livereload.
<img width="791" alt="image" src="https://github.com/ScottLogic/blog/assets/40387940/652c30f2-38df-4b93-b9ab-5a8c64982b60">

I set it up to serve a single user directory of your choosing, instead of all user directories. I did this because I use sparse checkout, so I only checkout one user directory (and one blog post) anyway. Other people may want to serve the whole blog, but for starters I'm just trying to provide a way to author one blog post.

@ColinEberhardt