### PR TITLE
Fix extra slashes in meta image url issue

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@ repository: ScottLogic/new-blog
     <meta property="og:title" content="{{ page.title | escape }}" />
     <meta property="og:description" content="{{ page.summary | escape }}"/>
     {% if page.image %}
-        {% assign thumbnailImage = site.canonical.url | append: '/' | append: page.image %}
+        {% assign thumbnailImage = page.image | prepend: '/' | replace : '//', '/' | prepend: site.canonical.url %}
     {% else %}
         {% assign thumbnailImage = site.canonical.url | append: '/assets/blog.png' %}
     {% endif %}


### PR DESCRIPTION
### Description
Fixes  #71 by removing extra slashes being added to the image meta URL

### Change List
- Update `default.html` to remove extra slashes if present

#### Before
![image](https://github.com/ScottLogic/blog/assets/93914995/5624aa37-5e93-499d-9626-97850ecb756a)

#### After
![image](https://github.com/ScottLogic/blog/assets/93914995/59dd003e-80de-44ed-89d7-c19a795493f0)

