### PR TITLE
Improve error response for generate-read-more workflow

### DIFF
--- a/scripts/generate-related/compute-embeddings.js
+++ b/scripts/generate-related/compute-embeddings.js
@@ -17,7 +17,7 @@ const { markdownToTxt } = require("markdown-to-txt");
     const filename = `${outputPath}/${file}`;
 
     if (!fs.existsSync(filename)) {
-      await summarisePost(formatContent(path)).then((embedding) => {
+      await summarisePost(formatContent(path), file).then((embedding) => {
         fs.writeFileSync(filename, JSON.stringify(embedding, null, 2));
       });
     } 
@@ -36,7 +36,7 @@ const formatContent = (post) => {
   return text.split(/[\s]+/).slice(0, 1000).join(" ");
 };
 
-const summarisePost = async (data) => {
+const summarisePost = async (data, file) => {
   const OPENAI_API_KEY = process.env.npm_config_openai_api_key;
 
   return await fetch(
@@ -54,11 +54,13 @@ const summarisePost = async (data) => {
     })
     .then((res) => {
       if(res.status !== 200) {
+        console.log("failed to embed: " +  file)
         if(res.status === 401) {
           throw Error(res.statusText + " - check your OpenAI API key");
         }
         throw Error(res.statusText);
       }
+      return res.json()
     })
     .then((json) => {
       if (json.data) {

--- a/scripts/generate-related/compute-embeddings.js
+++ b/scripts/generate-related/compute-embeddings.js
@@ -19,9 +19,6 @@ const { markdownToTxt } = require("markdown-to-txt");
     if (!fs.existsSync(filename)) {
       await summarisePost(formatContent(path)).then((embedding) => {
         fs.writeFileSync(filename, JSON.stringify(embedding, null, 2));
-      }).catch((err) => {
-        console.log("failed to embed: ", filename);
-        console.log(err);
       });
     } 
   }
@@ -57,9 +54,11 @@ const summarisePost = async (data) => {
     })
     .then((res) => {
       if(res.status !== 200) {
-        throw new Error(res.statusText);
+        if(res.status === 401) {
+          throw Error(res.statusText + " - check your OpenAI API key");
+        }
+        throw Error(res.statusText);
       }
-      return res.json()
     })
     .then((json) => {
       if (json.data) {


### PR DESCRIPTION
### Description
Improve the error response for the generate-read-more workflow to cause the workflow to fail if the API returns error responses

### Change List
- Improve error handling within `compute-embeddings.js`

#### Example Failure:
![image](https://github.com/ScottLogic/blog/assets/93914995/0525756b-4821-4834-95c7-5fd6344393ff)
