### PR TITLE
Fix featured posts and add featuredImage flag

### DIFF
--- a/_includes/featured_posts.html
+++ b/_includes/featured_posts.html
@@ -1,7 +1,7 @@
 {% if include.categoryName == "Latest Articles" %}
   {% assign featuredPosts = site.tags.featured %}
 {% else %}
-  {% assign featuredPosts = site.emptyArray %}
+  {% assign featuredPosts = '' | split: '' %}
   {% for post in include.postsToFilter %}
     {% if post.tags contains 'featured' %}
       {% assign featuredPosts = featuredPosts | push: post %}
@@ -51,7 +51,7 @@
           <polygon points="0 0 650 0 650 109.736 353 410 0 410"/>
         </svg>
       {% endcase %}
-      {% if post.image %}
+      {% if post.image and post.featuredImage %}
         <img class="cell show-for-large" src="{{ site.baseurl }}/{{post.image}}"/>
       {% endif %}
     </div>

--- a/_layouts/default_post.html
+++ b/_layouts/default_post.html
@@ -92,10 +92,9 @@ layout: default
       <div class="cell post-content">
         {{ content }}
       </div>
-
-      {% include read_more.html author=author authorUsername=authorUsername page=page %}
-
+      
       {% if site.data.related contains post.url %}
+        {% include read_more.html author=author authorUsername=authorUsername page=page %}
         {% assign related = site.data.related[post.url] %}
         {% assign posts = site.posts | where_exp:"item", "item.url == related[0]" %}
         {% include post_summary_list.html posts=posts hideCategory=true %}


### PR DESCRIPTION
### Description
Fixes issue #75 where featured posts weren't being shown in category pages, as well as removes `read more` if there are no related posts. Adds flag to stop showing auto-generated title images for featured posts unless altered

### Change List
- Fixes added to `feature_posts.html` and `default_post.html`
- Allow for new featuredImage flag to be used in `featured_posts.html`

#### Example without auto-gen title cards in featured posts
![image](https://github.com/ScottLogic/blog/assets/93914995/f7e720f3-ad9e-4f09-b8d3-b539f9ed1c2f)


#### How to use featuredImage flag
If a post has a specifically added title image, that will want to be shown in the featured posts section, then the post will need to include `featuredImage: true` within the post metadata.
