### PR TITLE
Add sustainability category

### DIFF
--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -22,6 +22,9 @@
 -  title: Artificial Intelligence
    url: /category/ai.html
 
+-  title: Sustainability
+   url: /category/sustainability.html
+
 -  title: Data Engineering
    url: /category/data-engineering.html
 

--- a/_posts/2022-04-07-cloud-sustainability-reach-net-zero.md
+++ b/_posts/2022-04-07-cloud-sustainability-reach-net-zero.md
@@ -4,6 +4,8 @@ title: Cloud sustainability - Could using the cloud help your organisation reach
 date: 2022-04-07 00:00:00 Z
 categories:
 - dsmith
+- Sustainability
+tags:
 - Cloud
 author: dsmith
 layout: default_post

--- a/_posts/2023-07-20-Environmental-Impact-The-supplier-problem.md
+++ b/_posts/2023-07-20-Environmental-Impact-The-supplier-problem.md
@@ -3,6 +3,7 @@ title: Environmental Impact – The supplier problem
 date: 2023-07-20 00:00:00 Z
 categories:
 - People
+- Sustainability
 summary: Those involved in managing organisations' environmental impact often point
   to the 'supply chain challenge', that is, the difficulty of measuring the GHG emissions
   associated with suppliers' goods and services. But most businesses are themselves

--- a/_posts/2023-09-12-sustainability-terminology.md
+++ b/_posts/2023-09-12-sustainability-terminology.md
@@ -2,9 +2,10 @@
 title: A guide to Software Sustainability terminology
 date: 2023-09-12 00:00:00 Z
 categories:
-- Tech
+- Sustainability
 tags:
 - Sustainability
+- Tech
 summary: You think software has enough variables, right? Well there is another one
   that has become a big consideration when designing, developing and deploying software
   and its name is Sustainability. This area of consideration comes with its own terminology

--- a/_posts/2023-09-27-architecting-a-regenerative-future-thoughts-from-intersection23.markdown
+++ b/_posts/2023-09-27-architecting-a-regenerative-future-thoughts-from-intersection23.markdown
@@ -3,6 +3,7 @@ title: 'Architecting a regenerative future: Thoughts from INTERSECTION23'
 date: 2023-09-27 19:18:00 Z
 categories:
 - ocronk
+- Sustainability
 tags:
 - sustainability
 - sustainable software

--- a/_posts/2023-09-28-embodied-carbon-from-software-development.md
+++ b/_posts/2023-09-28-embodied-carbon-from-software-development.md
@@ -2,9 +2,10 @@
 title: Being honest about Embodied Carbon from Software Development
 date: 2023-09-28 00:00:00 Z
 categories:
-- Tech
+- Sustainability
 tags:
 - Sustainability
+- Tech
 summary: Carbon emissions come in all shapes and sizes, in this blog post I talk about
   the more elusive sources of embodied carbon from software development.
 author: jhowlett

--- a/_posts/2023-10-19-tools-for-measuring-cloud-carbon-emissions.md
+++ b/_posts/2023-10-19-tools-for-measuring-cloud-carbon-emissions.md
@@ -8,6 +8,7 @@ categories:
 tags:
 - Cloud
 - Sustainability
+- featured
 summary: In this post I'll discuss ways of estimating the emissions caused by your
   Cloud workloads as a first step towards reaching your organisation's Net Zero goals.
 author: dsmith

--- a/_posts/2023-10-19-tools-for-measuring-cloud-carbon-emissions.md
+++ b/_posts/2023-10-19-tools-for-measuring-cloud-carbon-emissions.md
@@ -3,7 +3,11 @@ title: Tools for measuring Cloud Carbon Emissions
 date: 2023-10-19 00:00:00 Z
 categories:
 - dsmith
+- Sustainability
 - Cloud
+tags:
+- Cloud
+- Sustainability
 summary: In this post I'll discuss ways of estimating the emissions caused by your
   Cloud workloads as a first step towards reaching your organisation's Net Zero goals.
 author: dsmith

--- a/_posts/2023-10-26-conscientious-computing-facing-into-big-tech-challenges.markdown
+++ b/_posts/2023-10-26-conscientious-computing-facing-into-big-tech-challenges.markdown
@@ -2,15 +2,15 @@
 title: Conscientious Computing - facing into big tech challenges
 date: 2023-10-26 10:42:00 Z
 categories:
-- sustainability
-- architecture
+- Sustainability
 - ocronk
-- Tech
-- cloud
 tags:
 - sustainable software
-- sustainability
+- Sustainability
 - ocronk
+- architecture
+- Tech
+- cloud
 summary: The tech industry has driven incredibly rapid innovation by taking advantage
   of increasingly cheap and more powerful computing – but at what unintended cost?
   What collateral damage has been created in our era of "move fast and break things"?

--- a/_posts/2023-10-26-conscientious-computing-facing-into-big-tech-challenges.markdown
+++ b/_posts/2023-10-26-conscientious-computing-facing-into-big-tech-challenges.markdown
@@ -2,8 +2,11 @@
 title: Conscientious Computing - facing into big tech challenges
 date: 2023-10-26 10:42:00 Z
 categories:
+- architecture
 - Sustainability
 - ocronk
+- Tech
+- cloud
 tags:
 - sustainable software
 - Sustainability

--- a/_posts/2023-10-26-conscientious-computing-facing-into-big-tech-challenges.markdown
+++ b/_posts/2023-10-26-conscientious-computing-facing-into-big-tech-challenges.markdown
@@ -14,6 +14,7 @@ tags:
 - architecture
 - Tech
 - cloud
+- featured
 summary: The tech industry has driven incredibly rapid innovation by taking advantage
   of increasingly cheap and more powerful computing – but at what unintended cost?
   What collateral damage has been created in our era of "move fast and break things"?

--- a/_posts/2023-11-09-the-sustainable-computing-ecosystem.markdown
+++ b/_posts/2023-11-09-the-sustainable-computing-ecosystem.markdown
@@ -2,11 +2,12 @@
 title: The Sustainable Computing Ecosystem
 date: 2023-11-09 11:07:00 Z
 categories:
-- sustainability
+- Sustainability
 - Tech
 tags:
 - sustainable software
-- sustainability
+- Sustainability
+- Tech
 summary: 'Part of the Conscientious Computing series this blog talks about the emerging
   ecosystem of organisations that are promoting sustainability within software development,
   cloud computing, infrastructure, and digital services.'

--- a/category/sustainability.html
+++ b/category/sustainability.html
@@ -1,0 +1,12 @@
+---
+title: Sustainability
+layout: default
+summary: Scott Logic's thoughts and ideas relating to Sustainability
+image: "/assets/blog.png"
+---
+
+{% assign posts = site.categories["Sustainability"] %}
+{% if posts %}
+  {% assign posts = posts | sort: 'date' | reverse | uniq %}
+{% endif %}
+{% include post_index.html posts=posts categoryName="Sustainability" %}


### PR DESCRIPTION
### Description
It seems as though a sustainability category was added and removed by siteleaf, so this PR re-adds that category.

### Change List
- Add sustainability category
- Add `Sustainability` category to a few posts
- Add two posts from category to `featured` tag

### Example View
![image](https://github.com/ScottLogic/blog/assets/93914995/077fdcc3-99b3-4c00-8b5d-7d48cd61adbc)
