### PR TITLE
Fix categories not showing at top of post summary

### DIFF
--- a/_includes/category_display.html
+++ b/_includes/category_display.html
@@ -1,5 +1,6 @@
 {% assign post = include.post %}
 {% assign read_more = include.read_more %}
+{% assign found_category = "false" %}
 
 <span class="category">
     {% for post_category in post.categories | downcase %}


### PR DESCRIPTION
### Description
Fixes #113 where categories were not being shown for posts.

### Change List
- Fixed bug in `category_display.html`

#### Before
![image](https://github.com/ScottLogic/blog/assets/93914995/ed45081c-d5a3-4f25-a8c6-ba98aa76b2c6)


#### After
![image](https://github.com/ScottLogic/blog/assets/93914995/ba9a3ba8-5cd6-47bd-bb64-83cfa5bc3415)
