### PR TITLE
Update local development instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,35 @@ Thorough instructions for setting up your development environment are detailed b
 
 ### Native environment
 
-#### Linux prerequisites
+#### Prerequisites
 
-Install Ruby 2.3 and a few build dependencies for Nokogiri.
+First, install Ruby and (if on Linux) a few build dependencies for Nokogiri.
+
+On Linux:
 
 ```bash
 sudo apt-get install ruby2.3 ruby2.3-dev build-essential dh-autoreconf libxslt-dev libxml2-dev zlib1g-dev
 ```
 
-Update Gem and install the Jekyll, Bundler and Nokogiri gems.
+On Windows, if you use Chocolatey, simply run `choco install ruby` in a PowerShell instance
+with elevated priveleges. If you don't use Chocolatey, you can use [RubyInstaller][rubyinstaller]
+or see the Ruby website for [alternative ways to install Ruby][ruby-installation-instructions].
+You don't need to install any other dependencies on Windows at this stage.
+
+Secondly, update Gem and install the Jekyll, Bundler and Nokogiri gems.
+
+On Linux:
 
 ```bash
 sudo gem update
 sudo gem install jekyll bundler nokogiri
+```
+
+On Windows, in a PowerShell instance with elevated priveleges:
+
+```bash
+gem update
+gem install jekyll bundler nokogiri
 ```
 
 Thirdly, configure Bundler to store project dependencies in `vendor/bundle`, and,
@@ -89,7 +105,7 @@ cd PATH/TO/BLOG
 bundle install
 ```
 
-Run `jekyll -v` to check whether Jekyll is working. If so, you're good to run the blog!
+Finally, run `jekyll -v` to check whether Jekyll is working. If so, you're good to run the blog!
 
 #### Running in the native environment
 
@@ -144,6 +160,8 @@ Visit the blog on [localhost][localhost].
 [localhost]: http://localhost:4000
 [ruby-github-pages]: https://rubygems.org/gems/github-pages
 [ruby-bundler]: https://bundler.io/
+[rubyinstaller]: https://rubyinstaller.org/
+[ruby-installation-instructions]: https://www.ruby-lang.org/en/documentation/installation
 [ruby-nokogiri]: https://nokogiri.org/
 [ruby-liquid]: https://shopify.github.io/liquid/
 [ruby-downloads]: https://www.ruby-lang.org/en/downloads/

--- a/README.md
+++ b/README.md
@@ -67,19 +67,34 @@ Thorough instructions for setting up your development environment are detailed b
 
 #### Linux prerequisites
 
-1. sudo apt-get install ruby2.3 ruby2.3-dev build-essential dh-autoreconf
-2. sudo gem update
-3. sudo gem install jekyll bundler
-4. Run 'jekyll -v' to check whether Jekyll is working
-5. bundle config path vendor/bundle
-6. gem install bundler
-7. sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev
-8. sudo gem install nokogiri
-9. bundle install
+Install Ruby 2.3 and a few build dependencies for Nokogiri.
+
+```bash
+sudo apt-get install ruby2.3 ruby2.3-dev build-essential dh-autoreconf libxslt-dev libxml2-dev zlib1g-dev
+```
+
+Update Gem and install the Jekyll, Bundler and Nokogiri gems.
+
+```bash
+sudo gem update
+sudo gem install jekyll bundler nokogiri
+```
+
+Thirdly, configure Bundler to store project dependencies in `vendor/bundle`, and,
+when in the root directory of your clone of the blog, install the project dependencies.
+
+```bash
+bundle config path vendor/bundle
+cd PATH/TO/BLOG
+bundle install
+```
+
+Run `jekyll -v` to check whether Jekyll is working. If so, you're good to run the blog!
 
 #### Running in the native environment
 
-Once you've carried out the prerequisites for your operating system, you can run the blog.
+Once you've got all the prerequisites for your operating system, you can run the blog.
+Navigate to the root directory of your clone of the blog and execute Jekyll using Bundler.
 
 ```bash
 bundle exec jekyll serve

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Instead, please see our [company extranet][confluence-getting-started]
 for instructions on how to create a new page and view it before publication on the blog.
 
 ## Technical Stack
+
 The blog is a static website, designed to be hosted on [GitHub pages][github-pages].
 
 The underlying content is generated through a series of Ruby gems and libraries, starting with a dedicated github-pages [gem][ruby-github-pages].
@@ -46,7 +47,7 @@ __NOTE__: Instructions are work in progress.
 
 If you plan to use Docker, then you can [skip ahead][install-docker] now!
 
-The blog consists of static HTML pages with content generated using: 
+The blog consists of static HTML pages with content generated using:
 - [github-pages][ruby-github-pages] for deployment hooks
 - [Jekyll][jekyll-docs] for static site generation generator
 - [Kramdown][kramdown-syntax] for an extended markdown syntax
@@ -56,12 +57,45 @@ The blog consists of static HTML pages with content generated using:
 - [Bundler][ruby-bundler] to manage gems and dependencies
 - [Ruby][ruby-downloads].
 
-_In theory_, given that you've installed Ruby and Bundler, 
-and that the project contains a valid [Gemfile][project-gemfile],
-then using Bundler should bring in most of the dependencies automatically,
-however, due to Nokogiri's reliance on Native XML parsers you may require additional steps.
+_In theory_, once you've installed Ruby and Bundler,
+given that the project contains a valid [Gemfile][project-gemfile],
+then using Bundler should bring in most of the dependencies automatically.
+However, due to Nokogiri's reliance on Native XML parsers you may require additional steps.
+Thorough instructions for setting up your development environment are detailed below.
 
-### Docker:
+### Native environment
+
+#### Linux prerequisites
+
+1. sudo apt-get install ruby2.3 ruby2.3-dev build-essential dh-autoreconf
+2. sudo gem update
+3. sudo gem install jekyll bundler
+4. Run 'jekyll -v' to check whether Jekyll is working
+5. bundle config path vendor/bundle
+6. gem install bundler
+7. sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev
+8. sudo gem install nokogiri
+9. bundle install
+
+#### Running in the native environment
+
+Once you've carried out the prerequisites for your operating system, you can run the blog.
+
+```bash
+bundle exec jekyll serve
+```
+
+The blog will then be available on [localhost][localhost].
+
+If you need to re-compile the scripts or SCSS, you can use the NPM scripts.
+
+```bash
+npm install
+npm run scripts
+npm run style
+```
+
+### Docker
 
 Use a bash-compatible shell.
 
@@ -81,35 +115,7 @@ Now we can serve the blog:
 BLOG_USERNAME=abirch ./shell/docker-dev-watch.sh
 ```
 
-Visit the blog at:  
-http://localhost:4000
-
-### Linux:
-
-1. sudo apt-get install ruby2.3 ruby2.3-dev build-essential dh-autoreconf
-2. sudo gem update
-3. sudo gem install jekyll bundler
-4. Run 'jekyll -v' to check whether Jekyll is working
-5. bundle config path vendor/bundle
-6. gem install bundler
-7. sudo apt-get install libxslt-dev libxml2-dev zlib1g-dev
-8. sudo gem install nokogiri
-9. bundle install
-10. bundle exec jekyll serve
-11. Uncomment the lines in \_config.yml
-12. Access on http://localhost:4000
-
-## Additional Tasks:
-
-To minify JS, run:
-```
-npm run scripts
-```
-
-To minify SCSS, run:
-```
-npm run style
-```
+Visit the blog on [localhost][localhost].
 
 [confluence-getting-started]: https://scottlogic.atlassian.net/wiki/spaces/INT/pages/3577479175/Getting+started+with+the+Scott+Logic+blog
 [sparse-checkout-guide]: https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/#sparse-checkout-and-partial-clones
@@ -120,6 +126,7 @@ npm run style
 [github-pages-docs]: https://docs.github.com/en/pages
 [jekyll-docs]: https://jekyllrb.com/docs/
 [kramdown-syntax]: https://kramdown.gettalong.org/syntax.html
+[localhost]: http://localhost:4000
 [ruby-github-pages]: https://rubygems.org/gems/github-pages
 [ruby-bundler]: https://bundler.io/
 [ruby-nokogiri]: https://nokogiri.org/
@@ -127,3 +134,4 @@ npm run style
 [ruby-downloads]: https://www.ruby-lang.org/en/downloads/
 [project-gemfile]: Gemfile
 [install-docker]: #docker
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ If you wish to develop changes to the blog locally, you may find that there's a 
 git clone --depth 1 --filter=blob:none --no-checkout git@github.com:ScottLogic/blog.git
 cd blog
 git sparse-checkout init --cone
-# modify this variable with the author name you wish to write posts under (typically derived from your SL email address)
+# if you want to write blog posts, modify this variable with the author name you
+# wish to write posts under (typically derived from your SL email address)
 AUTHOR='abirch'
 git sparse-checkout set _includes _layouts _data category scripts scss assets "$AUTHOR"
 git checkout gh-pages


### PR DESCRIPTION
Following on from Ian's updates to the README (#116) this should bring the instructions for developing locally up-to-date.

Will Oliver kindly checked that the new instructions for Windows worked on his relatively clean machine.

I haven't been able to check if the Linux instructions are still up-to-date, though I have tidied them up a little.