### PR TITLE
Fix/image elements have alt text

### DIFF
--- a/_includes/featured_posts.html
+++ b/_includes/featured_posts.html
@@ -52,7 +52,8 @@
         </svg>
       {% endcase %}
       {% if post.image and post.featuredImage %}
-        <img class="cell show-for-large" src="{{ site.baseurl }}/{{post.image}}"/>
+        {% capture image-path %}{{ site.baseurl }}/{{post.image}}{% endcapture %}
+        <img class="cell show-for-large" alt="thumbnail of post: '{{post.title}}'" src="{{ image-path | replace: "//", "/" }}"/>
       {% endif %}
     </div>
   </div>

--- a/_posts/2023-07-13-accessibility-considerations.markdown
+++ b/_posts/2023-07-13-accessibility-considerations.markdown
@@ -72,11 +72,12 @@ Accessibility isn’t a feature that can be added at any point of product life-c
 
 * Use ARIA roles and attributes to provide additional context and meaning to UI elements.
 
-* Provide alternative text for Images to allow users with visual impairments to understand the content of images. Additionally, avoid using <img> for purely decorative elements as to reduce screen-reader’s noise.
+* Provide alternative text for Images to allow users with visual impairments to understand the content of images. 
+Additionally, avoid using &lt;img&gt; for purely decorative elements as to reduce screen-reader’s noise.
 
 * Use descriptive link text to help users to understand the destination of links.
 
-* Ensure users can navigate through the software by keyboard, not only mouse
+* Ensure users can navigate through the software by keyboard, not only mouse.
   Ensure good colour contrast to ensure that text and UI elements are readable by everyone.
 
 * Refrain from using JavaScript when possible to ensure that your software is accessible to users who cannot use JavaScript.


### PR DESCRIPTION
Automated acceptance testing by axe-core has flagged up a couple of pages where an `<img>` tag had no alt text, potentially causing difficulties for people e.g. using a screen reader.
- _posts/2023-07-13-accessibility-considerations.markdown
- index.html

## Investigation ##
**accessibility-considerations** 
Img tag occurs as literal content - brackets replaced with encoded values `&lt;`, `&gt;`.

### Before ###
https://blog.scottlogic.com/2023/07/13/accessibility-considerations.html

### After ###
https://ithake.github.io/blog-slogic/2023/07/13/accessibility-considerations.html

**index.html**
Through a series of includes the index page renders **featured-posts.html** which displays an img without an alt text for each featured blog where the screen is wide enough, and the given blog has truthy values for both `image` and `featuredImage` variables.

- Added `alt` attribute using `post.title`.
- Tested by manually setting the `featuredImage` variables.
- While testing, noticed that because there's no standard for the value of "image", some posts have it set with a preceding "/" and some without, and only the values without a slash get rendered.
-  Fixed by always adding a preceding slash, then removing the cases where there's a double slash.
I would have preferred to have the logic check for a preceding slash, but AFAIK that needed to split the string into an array of chars first so this implementation seemed simpler.

### Before
Now displaying proposed alt text...
[
![with-double-slash](https://github.com/ScottLogic/blog/assets/5435709/421da388-05d2-499e-9e1a-9e294ab2b6a0)
](url)

### After
![trim-double-slash](https://github.com/ScottLogic/blog/assets/5435709/3ddb768c-f88e-463d-9d30-30615efd190a)

 
Have you (please tick each box to show completion):
 - [ n/a ] Added your blog post to a single category?
 - [ n/a ] Added a brief summary for your post? Summaries should be roughly two sentences in length and give potential readers a good idea of the contents of your post.
 - [X] Checked that the build passes?
 - [ n/a ] Checked your spelling (you can use `npm spellcheck` if that's your thing)
 - [ n/a ] Ensured that your author profile contains a profile image, and a brief description of yourself? (make it more interesting than just your job title!)
 - [ n/a ] Optimised any images in your post? They should be less than 100KBytes as a general guide.

Posts are approved based on their category. replace `(at)` with `@` to notify them!

 - Tech - Colin Eberhardt - @ColinEberhardt
 - Cloud - Colin Eberhardt - (at)ColinEberhardt
 - Delivery - Matt Phillips - (at)scottlogicmphillips
 - UX - Graham Odds - (at)godds
 - People - Graham Odds - (at)godds
 - Testing - Laurence Pisani - (at)lpisani-SL
