### PR TITLE
LLM training: Fix typo

### DIFF
--- a/_posts/2023-11-24-llm-mem.md
+++ b/_posts/2023-11-24-llm-mem.md
@@ -294,7 +294,7 @@ Our understanding is as follows:
     </tr>
     <tr>
       <th>Gradients</th>
-      <td>4 bytes/param*** <abbr title="if (and only if)">iff</abbr> unused</td>
+      <td>4 bytes/param*** if unfused</td>
     </tr>
     <tr>
       <th colspan="2">Optimiser states</th>


### PR DESCRIPTION
https://scottlogic-alex.github.io/blog-2/2023/11/24/llm-mem.html

unused -> unfused.  
I also had to simplify iff to if, to make it fit on one line.

Before:  
<img width="581" src="https://user-images.githubusercontent.com/40387940/285517447-fa3bb75c-9973-4c8f-ac06-b953af77c4f0.png">

After:  
<img width="581" src="https://github.com/ScottLogic/blog/assets/40387940/f9fcdfbd-b28b-461c-b1eb-a887308f3af8">

Have you (please tick each box to show completion):

 - [x] Added your blog post to a single category?
 - [x] Added a brief summary for your post? Summaries should be roughly two sentences in length and give potential readers a good idea of the contents of your post.
 - [x] Checked that the build passes?
 - [x] Checked your spelling (you can use `npm spellcheck` if that's your thing)
 - [x] Ensured that your author profile contains a profile image, and a brief description of yourself? (make it more interesting than just your job title!)
 - [x] Optimised any images in your post? They should be less than 100KBytes as a general guide.

@ColinEberhardt fix typo (unfused instead of unused)