### PR TITLE
Fix: code blocks not keyboard focusable

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,0 +1,91 @@
+name: Build and Deploy to Github Pages
+
+concurrency:
+  group: "deployment"
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - gh-pages
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build the blog and upload as a GitHub Pages artifact
+    runs-on: ubuntu-latest
+
+    env:
+      # Used by the setup-ruby action as an alternative to `bundle config path`.
+      # see https://github.com/ruby/setup-ruby#bundle-config
+      BUNDLE_PATH: vendor/bundle
+
+    steps:
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Store the CNAME as an environment variable
+        run: echo "CNAME=$(cat CNAME)" >> $GITHUB_ENV
+
+      # Currently, scripts and SCSS are compiled locally and pushed to the repo.
+      # If we ever wanted to automate this process, we could do so as below.
+#     - name: Setup Node
+#       uses: actions/setup-node@v4
+#       with:
+#         node-version: 20.10.x
+#         cache: npm
+
+#     - name: Install NPM dependencies
+#       run: npm ci
+
+#     - name: Build scripts
+#       run: npm run scripts
+
+#     - name: Build SCSS
+#       run: npm run style
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true # Runs `bundle install` and caches gems
+          cache-version: 0 # want to trash the cache and download all the gems again? increment this number!
+
+      - name: Build the blog
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+
+      - name: Package and upload the build output as a GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v2
+
+  deploy:
+    name: Deploy the artifact to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - id: deploy
+        name: Deploy the artifact to GitHub Pages
+        uses: actions/deploy-pages@v2
+
+      - name: Log output page URL
+        run: echo "${{ steps.deploy.outputs.page_url }}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'http://rubygems.org'
 gem 'github-pages'
-
-
+gem "nokogiri", "~> 1.15.4"
 gem "tzinfo-data", "~> 1.2022"
-
 gem "webrick", "~> 1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'http://rubygems.org'
-gem 'github-pages'
+gem "jekyll", "~> 3.9.3"
+gem "jekyll-redirect-from", "~> 0.16.0"
 gem "nokogiri", "~> 1.15.4"
 gem "tzinfo-data", "~> 1.2022"
 gem "webrick", "~> 1.7"

--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,6 @@ canonical:
 scottlogic:
   url: https://www.scottlogic.com
 permalink: "/:year/:month/:day/:title.html"
-safe: true
 twitter_handle: Scott_Logic
 plugins:
 - jekyll-redirect-from

--- a/_plugins/make_code_blocks_keyboard_focusable.rb
+++ b/_plugins/make_code_blocks_keyboard_focusable.rb
@@ -1,0 +1,20 @@
+require 'nokogiri'
+
+Jekyll::Hooks.register :documents, :post_render do |document|
+  Jekyll.logger.debug "Making code blocks keyboard focusable in #{document.relative_path}..."
+  count_code_blocks = 0
+
+  html = Nokogiri.HTML5(document.output)
+  html.css('pre').each do |pre|
+    pre['tabindex'] = '0' unless pre.has_attribute?('tabindex')
+    count_code_blocks += 1
+  end
+
+  document.output = html.to_html
+  if count_code_blocks > 0 then
+    Jekyll.logger.info "Made #{count_code_blocks} code blocks keyboard focusable in #{document.relative_path}."
+  else
+    Jekyll.logger.debug "Made #{count_code_blocks} code blocks keyboard focusable in #{document.relative_path}."
+  end
+end
+


### PR DESCRIPTION
TODO:

* ensure all comments are sufficiently addressed
* put up a preview deployment

Before merging, carry out these [important steps](#important-steps)!

This PR makes code blocks usable to people who use a keyboard as their primary input modality. As a result of the technical requirements for this, it also replaces our current, plug-and-play build-and-deploy process with a custom GitHub Actions workflow.

## The problem: code blocks not keyboard-focusable

Many blog posts contain code blocks. Some of these are wide enough that you need to scroll horizontally to read all the content. (If a user happens to increase font size, for example, because they have limited vision, this will be true of more code blocks for them.)

In order for users who navigate primarily with the keyboard to be able to scroll these code blocks horizontally, they need to be present in the tab order. However, on Chrome and Edge (not sure about Safari) code blocks are not present in the tab order by default. To fix this, you have to attach the `tabindex` attribute yourself with a value greater than or equal to `0`.

## The solution: a custom Jekyll plugin

This PR implements a custom Jekyll plugin, [make_code_blocks_keyboard_focusable.rb][make-code-blocks-keyboard-focusable]. It takes in every post after it has been converted to HTML, picks out every `<pre>` element (which always wraps `<code>` blocks in order to preserve whitespace), and, if the `tabindex` attribute isn't already present, sets it to `0`. This means you can focus code blocks with the keyboard and scroll them horizontally with the arrow keys, no matter which browser you're using.

### Are there better solutions?

- If someone had already written this plugin, that would have saved us some effort. But I can't find any such plugin. (In any case, writing the plugin is not the burden of the effort for this change, and we've already done it now.)
- You could add the `tabindex` manually. But this has several drawbacks:
  - Most authors don't write code themselves, they use SiteLeaf to generate Markdown. We can't control how SiteLeaf generates Markdown.
  - Realistically, even when authors write their own code, authors are simply unlikely to add the `tabindex`. It's not obvious, so they'd need to read some instructions to tell them to do it. But nobody reads instructions, ever. Even if they did, they'd need to remember to do it when they actually got round to writing the code. But they would often forget.
  - Even when authors write their own code, and they read the instructions, and they remember, if they're writing Markdown, it is technically impossible. They can add a `tabindex`, but it'll go on a `div` wrapper around the code block, and this won't solve the problem of being able to scroll the code block (@ithake has tested this).
- You could write a Markdown preprocessor which adds `tabindex` to code blocks. But:
  - This has the same problem mentioned before, that the `tabindex` goes on a `div` wrapper, which means the problem isn't solved.
  - It wouldn't fix HTML blog posts anyway.

## Why this affects our build-and-deploy process

With GitHub Pages, there are two kinds of "publishing source": you can "publish from a branch" or write a custom GitHub Actions workflow file. (See [Pages docs on publishing sources][pages-docs-publishing-sources].) Right now, we "publish from a branch", but to implement our custom plugin, we need to change to the custom workflow file approach.

### Costs vs benefits of changing our build process

Costs:

- Theoretically implies a maintenance cost for the workflow file. (In practice, we have few dependencies and those we do have have stable APIs, so I don't think there's likely to be a significant maintenance cost)

Benefits:

- Can get these code blocks to be accessible to keyboard users!
- From now on, can install whatever plugins we like
- From now on, we're in control of our build process, so if we want to change it in any way in future, we can

_NB. This should have no impact on authors. I've already tested this out with manual authoring anyway, but there's no reason to expect that SiteLeaf authors will be affected, either. What the pipeline does after they've committed their changes is not the author's problem._

### Publish from a branch, and why this isn't compatible with a custom plugin

The simplest publishing source is to "publish from a branch", as we do currently. This means you just push a Jekyll project to the `gh-pages` branch and some GitHub magic builds and deploys the website for you.

Under the hood, the build step for this is carried out by the [jekyll-build-pages][jekyll-build-pages] Action, which depends on the `github-pages` gem.

Meanwhile, the fix in this PR requires a custom plugin. In order to use custom plugins, you cannot run Jekyll in "safe mode". (For all that that makes the alternative sound "unsafe", it doesn't obviously have any dangerous consequences -- see [Jekyll configuration options docs][jekyll-docs-options] to get the full details on what this entails.)

But the `github-pages` gem is not compatible with unsafe mode. So when the jekyll-build-pages Action runs, since it depends on `github-pages`, it forces Jekyll to run in safe mode, which means it doesn't use our custom plugin.

Instead, we have to use the second "publishing source". That is, we have to write our own GitHub Action workflow file to write our own custom build-and-deploy workflow. That's what I've done in this PR.

### The custom build and deploy workflow

This does exactly what you would expect: it builds the project with `bundle exec jekyll build`, uploads the result and deploys it to GitHub Pages.

You can see it in action in [my fork][demo-build-and-deploy-workflow]! It deploys to [my personal GitHub Pages domain][demo-blog-deployment]. The workflow file is `build-and-deploy.yaml`.

<h2 id="important-steps">Important: steps to merge this PR if it's been approved</h2>

1. Go to repository Settings > Pages > Build and deployment.
2. Change the deployment "Source" from "Deploy from a branch" to "GitHub Actions". *
3. Set the "Custom domain" to "blog.scottlogic.com". **
4. Merge this PR.

\* Setting the publishing source will prevent GitHub from trying to deploy the blog from its automatic workflow as well as our custom one.
** If you don't explicitly set the custom domain here, it'll deploy to something like `scottlogic.github.io/blog`.

[demo-blog-deployment]: https://jcarstairs-scottlogic.github.io/blog
[demo-build-and-deploy-workflow]: https://github.com/jcarstairs-scottlogic/blog/deployments
[jekyll-build-pages]: https://github.com/actions/jekyll-build-pages
[jekyll-docs-options]: http://jekyllrb.com/docs/configuration/options/
[make-code-blocks-keyboard-focusable]: https://github.com/ScottLogic/blog/compare/gh-pages...ithake:blog-slogic:fix/code-blocks-not-keyboard-focusable?expand=1#diff-6095e9dfff7671b43549e5c87c20f1151ee969b8fd90989c1466d8588053f3e9
[pages-docs-publishing-sources]: https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#publishing-sources-for-github-pages-sites