### PR TITLE
Screen readers don't announce author's avatars

### DIFF
--- a/_includes/author_picture.html
+++ b/_includes/author_picture.html
@@ -1,11 +1,27 @@
 {% if author.picture %}
   {% if post.author %}
-  <img src="{{ site.baseurl }}/{{ post.author }}/{{ author.picture }}" alt="{{ author.name }}"/>
+  <img
+    src="{{ site.baseurl }}/{{ post.author }}/{{ author.picture }}"
+    role="presentation"
+    alt=""
+  />
   {% elsif page.author %}
-  <img src="{{ site.baseurl }}/{{ page.author }}/{{ author.picture }}" alt="{{ author.name }}"/>
+  <img
+    src="{{ site.baseurl }}/{{ page.author }}/{{ author.picture }}"
+    role="presentation"
+    alt=""
+  />
   {% else %}
-  <img src="{{ site.baseurl }}/assets/avatar.png" alt="{{ author.name }}"/>
+  <img
+    src="{{ site.baseurl }}/assets/avatar.png"
+    role="presentation"
+    alt=""
+  />
   {% endif %}
 {% else %}
-<img src="{{ site.baseurl }}/assets/avatar.png" alt="{{ author.name }}"/>
+<img
+  src="{{ site.baseurl }}/assets/avatar.png"
+  role="presentation"
+  alt=""
+/>
 {% endif %}


### PR DESCRIPTION
Previously, screen readers were announcing author's avatars. This was a problem, because the avatars are not informative and are just noise to screen reader users, and because it meant the author's name was getting announced twice, which could be frustrating to users.

In particular, there are two places where author's avatars appear. One is at the top of their own author page.

![Colin Eberhardt's author page](https://github.com/ScottLogic/blog/assets/118172583/67cd8b2a-f0ba-4898-a8df-efbd583f9d4b)

Previously, this was being announced (on NVDA + Firefox) as:

> graphic Colin Eberhardt
> Blog
> heading level 2 Colin Eberhardt

After this PR, it'll be announced as:

> Blog
> heading level 2 Colin Eberhardt

Likewise, the author avatar also appears in blog post index entries, underneath the excerpt.

![Colin Eberhardt's avatar and name underneath a blog excerpt](https://github.com/ScottLogic/blog/assets/118172583/4db9f7a7-587f-42ea-9c98-168b2adeeba3)

Previously, this was announced as:

> graphic Colin Eberhardt link Colin Eberhardt 18 T. H.  October 2023

Now, it is announced as:

> link Colin Eberhardt 18 T. H.  October 2023