### PR TITLE
Adds all HTMLCS contrast rules to ignores list in pa11yci configuration

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -10,7 +10,12 @@ if (!chromiumBin) {
 const baseUrl = 'http://localhost:4000';
 
 // Colour contrast is a known issue. If we ever fix the brand colours, this should be removed.
-const colourContrastRuleId = 'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail';
+const colourContrastRuleIds = [
+  // HTML CodeSniffer rule IDs come from section 1.4.3 of:
+  // https://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/
+  'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail', // normal text
+  'WCAG2AA.Principle1.Guideline1_4.1_4_3.G145.Fail', // large text
+];
 
 module.exports = {
   defaults: {
@@ -18,7 +23,7 @@ module.exports = {
       executablePath: chromiumBin,
     },
     ignore: [
-      colourContrastRuleId,
+      ...colourContrastRuleIds,
     ],
   },
   urls: relativeUrls.map((url) => `${baseUrl}${url}`),

--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -25,6 +25,8 @@ module.exports = {
     ignore: [
       ...colourContrastRuleIds,
     ],
+    reporter: 'cli',
+    runners: ['htmlcs'],
   },
   urls: relativeUrls.map((url) => `${baseUrl}${url}`),
 };


### PR DESCRIPTION
This PR will add all [HTML CodeSniffer contrast rules](https://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/) to the list of rules to ignore in the `.pa11yci.js` configuration file.

Running `pa11y-ci` locally, this removes the contrast issues erroneously detected on Fanis' post.

![Screenshot of contrast isues disappearing from the report on Fanis' post](https://github.com/ScottLogic/blog/assets/118172583/c65fc120-4d2c-4d11-a645-d0fcff8ef4a4)
