### PR TITLE
Correct image extension format in authors.yml

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1469,4 +1469,4 @@ authors:
     name: "Josh Isted"
     email: jisted@scottlogic.com
     author-summary: "Originally from a humanities and languages background, I'm now a Senior Developer at Scott Logic based in the Newcastle office, with an interest in a bit of everything tech-wise. Outside of that I like going to other countries trying to eat all of their food."
-    picture: jisted.jpg
+    picture: jisted.png


### PR DESCRIPTION
Small PR to correct profile pic field assumed to be a 'jpg' to a 'png'.

---

**N/A**
Please add a direct link to your post here:

https://<your-username>.github.io/blog/<post-url>

Have you (please tick each box to show completion):

 - [ ] Added your blog post to a single category?
 - [ ] Added a brief summary for your post? Summaries should be roughly two sentences in length and give potential readers a good idea of the contents of your post.
 - [ ] Checked that the build passes?
 - [ ] Checked your spelling (you can use `npm spellcheck` if that's your thing)
 - [ ] Ensured that your author profile contains a profile image, and a brief description of yourself? (make it more interesting than just your job title!)
 - [ ] Optimised any images in your post? They should be less than 100KBytes as a general guide.

Posts are reviewed / approved by your Regional Tech Lead.
