### PR TITLE
Bump to Node20 in github workflows

### DIFF
--- a/.github/workflows/auto-compress-images.yaml
+++ b/.github/workflows/auto-compress-images.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compress Images
         uses: calibreapp/image-actions@main
         with:

--- a/.github/workflows/check-a11y-of-changed-content.yaml
+++ b/.github/workflows/check-a11y-of-changed-content.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10.x
+          node-version: 20.x
           cache: npm
 
       - name: Install NPM dependencies

--- a/.github/workflows/generate-related.yaml
+++ b/.github/workflows/generate-related.yaml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.13.x
+          node-version: 20.x
           cache: npm
       - run: npm install
       - run: npm run compute-embeddings --OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/remove-unused-images.yaml
+++ b/.github/workflows/remove-unused-images.yaml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.13.x
+          node-version: 20.x
           cache: npm
       - run: npm install
       - name: Remove Unused Images


### PR DESCRIPTION
This is a maintenance change to upgrade Node in github workflows to v20 (as v16 is no longer supported), and related change to use `actions/setup-node@v4`.