### PR TITLE
Correcting algorithm blog links

### DIFF
--- a/_posts/2024-10-24-building-an-assignment-algorithm-1.markdown
+++ b/_posts/2024-10-24-building-an-assignment-algorithm-1.markdown
@@ -180,4 +180,4 @@ The weight gives more emphasis to the surplus difference if a user’s current g
 
 ### What's next?
 
-So you may be wondering, how do we define and measure compromise? And how can we do this over the course of multiple slots? These are good questions and will be answered in the next blog in the series. We’ll also get into the nitty gritty of the maths behind it all. Stay tuned!
+So you may be wondering, how do we define and measure compromise? And how can we do this over the course of multiple slots? These are good questions and are covered in the [next blog in the series]({{site.baseurl}}/2024/11/04/building-an-assignment-algorithm-2.html). We’ll also get into the nitty gritty of the maths behind it all. Stay tuned!

--- a/_posts/2024-11-04-building-an-assignment-algorithm-2.markdown
+++ b/_posts/2024-11-04-building-an-assignment-algorithm-2.markdown
@@ -68,7 +68,7 @@ author: jwarren
 </script>
 
 
-Last year, we were given the task to create a conference talk-assignment-algorithm, for our company’s internal conferences. In the [first blog]({{site.baseurl}}/2024/08/16/building-an-assignment-algorithm-1.html), we explored how to assign talks in a single time slot, which is really the bedrock of the algorithm. However, looking at the bigger picture, being fair across multiple time slots is also highly important. 
+Last year, we were given the task to create a conference talk-assignment-algorithm, for our company’s internal conferences. In the [first blog]({{site.baseurl}}/2024/10/24/building-an-assignment-algorithm-1.html), we explored how to assign talks in a single time slot, which is really the bedrock of the algorithm. However, looking at the bigger picture, being fair across multiple time slots is also highly important. 
 
 We would not want the same attendees to always get their second choice, or worse still their third choice across multiple slots. Therefore, to be able to empirically measure this, we conceptualised the amount by which a single attendee has received different choices in the past as a value called “compromise”. For example, an attendee didn’t get their first choice, so they had to compromise with a second/third choice.  
 


### PR DESCRIPTION
Please add a direct link to your post here:
[blog1](https://jwarren-scottlogic.github.io/blog/2024/10/21/building-an-assignment-algorithm-1.html)
[blog2](https://jwarren-scottlogic.github.io/blog/2024/10/21/building-an-assignment-algorithm-2.html#SlotCompromiseFormula)
Have you (please tick each box to show completion):

 - [X] Added your blog post to a single category?
 - [X] Added a brief summary for your post? Summaries should be roughly two sentences in length and give potential readers a good idea of the contents of your post.
 - [X] Checked that the build passes?
 - [X] Checked your spelling (you can use `npm install` followed by `npx mdspell "**/{FILE_NAME}.md" --en-gb -a -n -x -t` if that's your thing)
 - [X] Ensured that your author profile contains a profile image, and a brief description of yourself? (make it more interesting than just your job title!)
 - [X] Optimised any images in your post? They should be less than 100KBytes as a general guide.

Posts are reviewed / approved by your Regional Tech Lead.
