### PR TITLE
Change image to use github.url to allow testing of social media images

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,9 +26,9 @@ repository: ScottLogic/new-blog
     <meta property="og:title" content="{{ page.title | escape }}" />
     <meta property="og:description" content="{{ page.summary | escape }}"/>
     {% if page.image %}
-        {% assign thumbnailImage = page.image | prepend: '/' | replace : '//', '/' | prepend: site.canonical.url %}
+        {% assign thumbnailImage = page.image | prepend: '/' | replace : '//', '/' | prepend: site.github.url %}
     {% else %}
-        {% assign thumbnailImage = site.canonical.url | append: '/assets/blog.png' %}
+        {% assign thumbnailImage = site.github.url | append: '/assets/blog.png' %}
     {% endif %}
     <meta property="og:image" content="{{ thumbnailImage }}" />
     <meta property="og:type" content="article" />


### PR DESCRIPTION
Fixes #285 

No post associated with change, though I did make a test one to prove that a new image will now appear in the LinkedIn Post Inspector.

![Screenshot 2024-12-19 104409](https://github.com/user-attachments/assets/b5fe2760-0451-4fea-a530-b2dda245ca69)

Have you (please tick each box to show completion):

 - [x] Added your blog post to a single category?
 - [x] Added a brief summary for your post? Summaries should be roughly two sentences in length and give potential readers a good idea of the contents of your post.
 - [x] Checked that the build passes?
 - [x] Checked your spelling (you can use `npm install` followed by `npx mdspell "**/{FILE_NAME}.md" --en-gb -a -n -x -t` if that's your thing)
 - [x] Ensured that your author profile contains a profile image, and a brief description of yourself? (make it more interesting than just your job title!)
 - [x] Optimised any images in your post? They should be less than 100KBytes as a general guide.

Posts are reviewed / approved by your Regional Tech Lead.
