### PR TITLE
Use stable chrome version for running pa11y-ci

### DIFF
--- a/.github/workflows/check-a11y-of-changed-content.yaml
+++ b/.github/workflows/check-a11y-of-changed-content.yaml
@@ -54,11 +54,13 @@ jobs:
         run: npm ci
 
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1
         id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 'stable'
 
       - name: Wait for blog to be running
         run: npx wait-on http://localhost:4000 --timeout 60000
 
       - name: Run pa11y-ci
-        run: CHROMIUM_BIN=$(which chrome) npx pa11y-ci
+        run: CHROMIUM_BIN=${{ steps.setup-chrome.outputs.chrome-path }} npx pa11y-ci

--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -21,7 +21,7 @@ module.exports = {
   defaults: {
     chromeLaunchConfig: {
       executablePath: chromiumBin,
-      "args": ["--disable-setuid-sandbox"],
+      "args": ["--no-sandbox"],
     },
     ignore: [
       ...colourContrastRuleIds,

--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -21,6 +21,7 @@ module.exports = {
   defaults: {
     chromeLaunchConfig: {
       executablePath: chromiumBin,
+      "args": ["--disable-setuid-sandbox"],
     },
     ignore: [
       ...colourContrastRuleIds,


### PR DESCRIPTION
Use `stable` version of chrome (chromium) for running pa11y-ci tests, because `latest` version does not have adequate permissions.

Resolves #290 